### PR TITLE
feat: remove unnecessary promise creation to speed execution

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -8,15 +8,12 @@ exports.onCreatePage = ({ page, actions }, pluginOptions) => {
   const { createPage, deletePage } = actions
   const options = { ...defaultOptions, ...pluginOptions }
 
-  return new Promise(resolve => {
-    if(!options.excludedPaths.includes(page.path)) {
-      const oldPage = Object.assign({}, page)
-      page.path = replacePath(page.path)
-      if (page.path !== oldPage.path) {
-        deletePage(oldPage)
-        createPage(page)
-      }
+  if(!options.excludedPaths.includes(page.path)) {
+    const oldPage = Object.assign({}, page)
+    page.path = replacePath(page.path)
+    if (page.path !== oldPage.path) {
+      deletePage(oldPage)
+      createPage(page)
     }
-    resolve()
-  })
+  }
 }


### PR DESCRIPTION
Creating promises gets expensive at scale so avoiding them when possible is best.

Gatsby plugins only need promises when they do something async so it's safe to remove it here.