### PR TITLE
add deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+❗❗❗ Deprecation Notice: Gatsby now let you configure trailing slash out of the box. See [documentation](https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/)
+
 # gatsby-plugin-force-trailing-slashes
 
 This plugin is one component of unifying a Gatsby site to _use_ trailing slashes. To correctly configure a Gatsby site to use trailing slashes, you need the following **three** pieces in place:

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,22 +1,29 @@
-const replacePath = _path => (_path === `/` ? _path : _path.replace(/\/$|$/, `/`))
+const replacePath = (_path) =>
+  _path === `/` ? _path : _path.replace(/\/$|$/, `/`);
 
 const defaultOptions = {
-  excludedPaths: [`/404.html`]
-}
+  excludedPaths: [`/404.html`],
+};
 
 exports.onCreatePage = ({ page, actions }, pluginOptions) => {
-  const { createPage, deletePage } = actions
-  const options = { ...defaultOptions, ...pluginOptions }
+  const { createPage, deletePage } = actions;
+  const options = { ...defaultOptions, ...pluginOptions };
 
-  return new Promise(resolve => {
-    if(!options.excludedPaths.includes(page.path)) {
-      const oldPage = Object.assign({}, page)
-      page.path = replacePath(page.path)
+  return new Promise((resolve) => {
+    if (!options.excludedPaths.includes(page.path)) {
+      const oldPage = Object.assign({}, page);
+      page.path = replacePath(page.path);
       if (page.path !== oldPage.path) {
-        deletePage(oldPage)
-        createPage(page)
+        deletePage(oldPage);
+        createPage(page);
       }
     }
-    resolve()
-  })
-}
+    resolve();
+  });
+};
+
+exports.onPreInit = ({ reporter }) => {
+  reporter.warn(
+    `gatsby-plugin-force-trailing-slashes: Gatsby now let you configure trailing slash out of the box. See documentation https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/`
+  );
+};


### PR DESCRIPTION
Add deprecation notice since gatsby now provides support for trailing slash config out of the box

see: https://www.gatsbyjs.com/docs/reference/config-files/gatsby-config/#trailingslash/